### PR TITLE
Added Grape/HelpersIncludeModule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,4 +15,4 @@ Metrics/BlockLength:
     - spec/**/*_spec.rb
 
 RSpec/ExampleLength:
-  Max: 10
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # main
 
-* Added cop `Grape/HelpersIncludeModule`
+* Added cop `Grape/HelpersIncludeModule` ([#1](https://github.com/petalmd/rubocop-petal/pull/1))
 
 # v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+# main
+
+* Added cop `Grape/HelpersIncludeModule`
+
+# v0.1.0
+
+* First version

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,9 @@
+Grape/HelpersIncludeModule:
+  Description: 'Prevent using helpers with block to include module'
+  Enabled: true
+  Include:
+    - app/api/**/*
+
 Rails/EnumPrefix:
   Description: 'Set prefix options when using enums.'
   Enabled: true

--- a/lib/rubocop/cop/grape/helpers_include_module.rb
+++ b/lib/rubocop/cop/grape/helpers_include_module.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Grape
+      # Prevent usage of Grape `helpers` with a block to include module.
+      # Using a bloc will create a new unnecessary module.
+      #
+      #   # bad
+      #   helpers do
+      #     include MyModule
+      #   end
+      #
+      #   # bad
+      #   helpers do
+      #     include MyModule
+      #     include MyOtherModule
+      #   end
+      #
+      #   # good
+      #   helpers MyModule
+      #
+      #   # good
+      #   helpers MyModule, MyOtherModule
+      class HelpersIncludeModule < Base
+        MSG = 'Use `helpers %<module_name>s` instead of `helpers` with a block.'
+
+        def_node_matcher :helpers?, <<~PATTERN
+          (send nil? :helpers)
+        PATTERN
+
+        def_node_matcher :called_include?, <<~PATTERN
+          (send nil? :include (const _ $_))
+        PATTERN
+
+        def on_send(node)
+          return unless helpers?(node)
+
+          helpers_block_node = node.block_node.children.last
+          block_nodes = block_nodes_in_helpers(helpers_block_node)
+
+          block_nodes.each do |block_node|
+            if (module_name = called_include?(block_node))
+              add_offense(block_node, message: format(MSG, module_name: module_name))
+            end
+          end
+        end
+
+        private
+
+        def block_nodes_in_helpers(node)
+          if node.begin_type?
+            node.children
+          else
+            [node]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/grape/helpers_include_module_spec.rb
+++ b/spec/rubocop/cop/grape/helpers_include_module_spec.rb
@@ -19,6 +19,26 @@ RSpec.describe RuboCop::Cop::Grape::HelpersIncludeModule, :config do
         ^^^^^^^^^^^^^^^^^^^^^ Use `helpers MyOtherModule` instead of `helpers` with a block.
       end
     RUBY
+
+    expect_offense(<<~RUBY)
+      helpers do
+        include MyModule
+        ^^^^^^^^^^^^^^^^ Use `helpers MyModule` instead of `helpers` with a block.
+      #{'  '}
+        def def my_helper_method; end
+      end
+    RUBY
+
+    expect_offense(<<~RUBY)
+      helpers do
+        include MyModule
+        ^^^^^^^^^^^^^^^^ Use `helpers MyModule` instead of `helpers` with a block.
+      #{'  '}
+        def def my_helper_method; end
+        include MyOtherModule
+        ^^^^^^^^^^^^^^^^^^^^^ Use `helpers MyOtherModule` instead of `helpers` with a block.
+      end
+    RUBY
   end
 
   it 'does not register an offense when using `helpers` without a block to include module' do

--- a/spec/rubocop/cop/grape/helpers_include_module_spec.rb
+++ b/spec/rubocop/cop/grape/helpers_include_module_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Grape::HelpersIncludeModule, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using `helpers` with a block to include a module' do
+    expect_offense(<<~RUBY)
+      helpers do
+        include MyModule
+        ^^^^^^^^^^^^^^^^ Use `helpers MyModule` instead of `helpers` with a block.
+      end
+    RUBY
+
+    expect_offense(<<~RUBY)
+      helpers do
+        include MyModule
+        ^^^^^^^^^^^^^^^^ Use `helpers MyModule` instead of `helpers` with a block.
+        include MyOtherModule
+        ^^^^^^^^^^^^^^^^^^^^^ Use `helpers MyOtherModule` instead of `helpers` with a block.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using `helpers` without a block to include module' do
+    expect_no_offenses(<<~RUBY)
+      helpers MyModule
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      helpers MyModule, MyOtherModule
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      helpers do
+        def my_helper_method; end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
We use a lot the method `helpers` from Grape to include module. This method is able to take module as args to include them. Using the block create a new anonymous module.