### PR TITLE
RSpec::JsonParseResponseBody

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # main
 
-* Added cop `RSpec::JsonParseResponseBody and RSpec::JsonResponse` ([#27](https://github.com/petalmd/rubocop-petal/pull/27))
+* Added cop `RSpec/JsonParseResponseBody and RSpec/JsonResponse` ([#27](https://github.com/petalmd/rubocop-petal/pull/27))
 
 # v0.7.0
 
@@ -10,7 +10,7 @@
 
 # v0.6.0
 
-* Added cop `RSpec::SidekiqInline` ([#24](https://github.com/petalmd/rubocop-petal/pull/24))
+* Added cop `RSpec/SidekiqInline` ([#24](https://github.com/petalmd/rubocop-petal/pull/24))
 * Remove cop `Rails/ValidateUniquenessCase` ([#21](https://github.com/petalmd/rubocop-petal/pull/21))
 
 # v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # main
 
-* Added cop `RSpec::JsonParseResponseBody` ([#24](https://github.com/petalmd/rubocop-petal/pull/27))
+* Added cop `RSpec::JsonParseResponseBody and RSpec::JsonResponse` ([#27](https://github.com/petalmd/rubocop-petal/pull/27))
 
 # v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # main
 
+* Added cop `RSpec::JsonParseResponseBody` ([#24](https://github.com/petalmd/rubocop-petal/pull/27))
+
 # v0.7.0
 
 * Support more cases for `Grape/UnnecessaryNamespace`. ([#26](https://github.com/petalmd/rubocop-petal/pull/26))

--- a/config/default.yml
+++ b/config/default.yml
@@ -77,3 +77,17 @@ Rails/TableName:
 Chewy/ResetOnType:
   Description: 'Prevent using reset! methods on Chewy type class'
   Enabled: true
+
+RSpec/JsonParseResponseBody:
+  Description: 'Prevent JSON.parse(response.body) in favor of response.parsed_body'
+  Enabled: true
+  SafeAutoCorrect: true
+  Include:
+    - spec/**/*
+
+RSpec/JsonResponse:
+  Description: 'Prevent json_response in favor of response.parsed_body'
+  Enabled: true
+  SafeAutoCorrect: true
+  Include:
+    - spec/**/*

--- a/lib/rubocop/cop/rspec/json_parse_response_body.rb
+++ b/lib/rubocop/cop/rspec/json_parse_response_body.rb
@@ -14,6 +14,8 @@ module RuboCop
       #   response.parsed_body
       #
       class JsonParseResponseBody < Base
+        extend AutoCorrector
+
         MSG = 'Use `response.parsed_body` instead.'
 
         def_node_matcher :json_parse_response_body?, <<~PATTERN
@@ -23,7 +25,9 @@ module RuboCop
         def on_send(node)
           return unless json_parse_response_body?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            corrector.replace(node, 'response.parsed_body')
+          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/json_parse_response_body.rb
+++ b/lib/rubocop/cop/rspec/json_parse_response_body.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Prevent using `JSON.parse(response.body)` in spec.
+      # Consider using `response.parsed_body`.
+      #
+      # @example
+      #   # bad
+      #   JSON.parse(response.body) do; end
+      #
+      #   # good
+      #   response.parsed_body
+      #
+      class JsonParseResponseBody < Base
+        MSG = 'Use `response.parsed_body` instead.'
+
+        def_node_matcher :json_parse_response_body?, <<~PATTERN
+          (send (const _ :JSON) :parse (send (send _ :response) :body))
+        PATTERN
+
+        def on_send(node)
+          return unless json_parse_response_body?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/json_response.rb
+++ b/lib/rubocop/cop/rspec/json_response.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Prevent using `json_response` in spec.
+      # Consider using `response.parsed_body`.
+      #
+      # @example
+      #   # bad
+      #   expect(json_response)
+      #
+      #   # good
+      #   expect(response.parsed_body)
+      #
+      class JsonResponse < Base
+        extend AutoCorrector
+
+        MSG = 'Use `response.parsed_body` instead.'
+
+        def_node_matcher :json_response?, <<~PATTERN
+          (send _ :json_response)
+        PATTERN
+
+        def on_send(node)
+          return unless json_response?(node)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node, 'response.parsed_body')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/json_parse_response_body_spec.rb
+++ b/spec/rubocop/cop/rspec/json_parse_response_body_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::JsonParseResponseBody, :config do
-  it 'registers an offense when using `JSON.parse(response.body)`' do
+  it 'registers an offense when using `JSON.parse(response.body)`', :aggregate_failures do
     expect_offense(<<~RUBY)
       JSON.parse(response.body)
       ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `response.parsed_body` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      response.parsed_body
     RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/json_parse_response_body_spec.rb
+++ b/spec/rubocop/cop/rspec/json_parse_response_body_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::JsonParseResponseBody, :config do
+  it 'registers an offense when using `JSON.parse(response.body)`' do
+    expect_offense(<<~RUBY)
+      JSON.parse(response.body)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `response.parsed_body` instead.
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/rspec/json_response_spec.rb
+++ b/spec/rubocop/cop/rspec/json_response_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::JsonResponse, :config do
+  it 'registers an offense when using `json_response`', :aggregate_failures do
+    expect_offense(<<~RUBY)
+      json_response
+      ^^^^^^^^^^^^^ Use `response.parsed_body` instead.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      response.parsed_body
+    RUBY
+  end
+end


### PR DESCRIPTION
Add a new cop called `JsonParseResponseBody` that will check `JSON.parse(response.body)`. There's an autocorrector that simply replace the check by`response.parsed_body`

This is part of [ActionDispatch::TestResponse](https://api.rubyonrails.org/classes/ActionDispatch/TestResponse.html#method-i-parsed_body)