### PR TITLE
Snif cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 # main
 
+* Added cop `Performance/Snif` ([#31](https://github.com/petalmd/rubocop-petal/pull/31))
 * Updated gemspec file. ([#30](https://github.com/petalmd/rubocop-petal/pull/30))
 * Added cop `RSpec/JsonParseResponseBody and RSpec/JsonResponse` ([#27](https://github.com/petalmd/rubocop-petal/pull/27))
-* Added cop `Performance/Snif` ([#27](https://github.com/petalmd/rubocop-petal/pull/31))
 
 # v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Updated gemspec file. ([#30](https://github.com/petalmd/rubocop-petal/pull/30))
 * Added cop `RSpec/JsonParseResponseBody and RSpec/JsonResponse` ([#27](https://github.com/petalmd/rubocop-petal/pull/27))
+* Added cop `Performance/Snif` ([#27](https://github.com/petalmd/rubocop-petal/pull/31))
 
 # v0.7.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -91,3 +91,7 @@ RSpec/JsonResponse:
   SafeAutoCorrect: true
   Include:
     - spec/**/*
+
+Performance/Snif:
+  Description: 'Prevent snif in favor of detect'
+  Enabled: true

--- a/lib/rubocop/cop/performance/snif.rb
+++ b/lib/rubocop/cop/performance/snif.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # Prevent using `snif`.
+      # Consider using `detect`.
+      #
+      # @example
+      #   # bad
+      #   period.equity_packs.snif(:code, 'ONCALL')
+      #
+      #   # good
+      #   period.equity_packs.detect { |equity_pack| equity_pack.code == 'ONCALL' }
+      class Snif < Base
+        MSG = 'Use `detect` instead.'
+
+        def_node_matcher :snif?, <<~PATTERN
+            (send _ :snif _ _)
+        PATTERN
+
+        def on_send(node)
+          return unless snif?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/performance/snif.rb
+++ b/lib/rubocop/cop/performance/snif.rb
@@ -16,7 +16,7 @@ module RuboCop
         MSG = 'Use `detect` instead.'
 
         def_node_matcher :snif?, <<~PATTERN
-            (send _ :snif _ _)
+          (send _ :snif _ _)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/performance/snif_spec.rb
+++ b/spec/rubocop/cop/performance/snif_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Performance::Snif, :config do
+  it 'registers an offense when using `snif`', :aggregate_failures do
+    expect_offense(<<~RUBY)
+      test.snif(:attribute, value)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `detect` instead.
+    RUBY
+
+    expect_offense(<<~RUBY)
+      test.snif(attribute, value)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `detect` instead.
+    RUBY
+  end
+end


### PR DESCRIPTION
Adding a `snif` cop for performance issue. It's also a very old thing in our stack that is not following the convention.