### PR TITLE
SEME-1955-Rubocop-for-micro-service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-petal (0.8.0)
+    rubocop-petal (0.9.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-rails (~> 2.10)
 
@@ -22,7 +22,7 @@ GEM
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
-    rack (3.0.4.1)
+    rack (3.0.7)
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.2.0)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,17 @@
+Rails/ModelAccessFromApiController:
+  Description: 'Do not directly access models from within Rails Api / Controller.'
+  Enabled: false
+  VersionAdded: '0.9.0'
+  AutoCorrect: false
+  ControllersPath: app/controllers/
+  ApisPath: app/api/
+  ModelsPath: app/models/
+  DisabledApis: []
+  DisabledControllers: []
+  AllowedModels: []
+  Include:
+    - '**/*.rb'
+
 Grape/PreferNamespace:
   Description: 'Prevent usage of namespace aliases.'
   Enabled: true

--- a/lib/rubocop/cop/rails/model_access_from_api_controller.rb
+++ b/lib/rubocop/cop/rails/model_access_from_api_controller.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector'
+require 'digest/sha1'
+
+module RuboCop
+  module Cop
+    module Rails
+      # This cop checks for engines reaching directly into app/ models.
+      #
+      # Inspired by:
+      # https://flexport.engineering/isolating-rails-engines-with-rubocop-210feaba3164
+      # https://github.com/flexport/rubocop-flexport/pull/5/files
+      #
+      # With an ActiveRecord object, engine code can perform arbitrary
+      # reads and arbitrary writes to models located in the main `app/`
+      # directory. This cop helps isolate Rails Api code to ensure
+      # that modular boundaries are respected.
+      #
+      # Checks for both access via `MyModel.foo` and associations.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   class MyApi::MyService
+      #     m = SomeModel.find(123)
+      #     m.any_random_attribute = "whatever i want"
+      #     m.save
+      #   end
+      #
+      #   # good
+      #
+      #   class MyApi::MyService
+      #     ApiServiceForModels.perform_a_supported_operation("foo")
+      #   end
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   class MyApi::MyModel < ApplicationModel
+      #     has_one :some_model, class_name: "SomeModel"
+      #   end
+      #
+      #   # good
+      #
+      #   class MyApi::MyModel < ApplicationModel
+      #     # No direct association to global models.
+      #   end
+      #
+      class ModelAccessFromApiController < Base
+        MSG = 'Direct access of model from within Rails Api or Controller.'
+
+        def_node_matcher :rails_association_hash_args, <<-PATTERN
+          (send _ {:belongs_to :has_one :has_many} sym $hash)
+        PATTERN
+
+        def on_const(node)
+          return unless in_enforced_api_file? || in_enforced_controller_file?
+          return unless global_model_const?(node)
+          # The cop allows access to e.g. MyGlobalModel::MY_CONST.
+          return if child_of_const?(node)
+
+          add_offense(node)
+        end
+
+        def on_send(node)
+          return unless in_enforced_api_file? || in_enforced_controller_file?
+
+          rails_association_hash_args(node) do |assocation_hash_args|
+            class_name_node = extract_class_name_node(assocation_hash_args)
+            class_name = class_name_node&.value
+            next unless global_model?(class_name)
+
+            add_offense(class_name_node)
+          end
+        end
+
+        # Because this cop's behavior depends on the state of external files,
+        # we override this method to bust the RuboCop cache when those files
+        # change.
+        def external_dependency_checksum
+          Digest::SHA1.hexdigest(model_dir_paths.join)
+        end
+
+        private
+
+        def global_model_names
+          @global_model_names ||= calculate_global_models
+        end
+
+        def model_dir_paths
+          Dir[File.join(global_models_path, '**/*.rb')]
+        end
+
+        def calculate_global_models
+          all_model_paths = model_dir_paths.reject do |path|
+            path.include?('/concerns/')
+          end
+          all_models = all_model_paths.map do |path|
+            # Translates `app/models/foo/bar_baz.rb` to `Foo::BarBaz`.
+            file_name = path.gsub(global_models_path, '').gsub('.rb', '')
+            ActiveSupport::Inflector.classify(file_name)
+          end
+          all_models - allowed_global_models
+        end
+
+        def extract_class_name_node(assocation_hash_args)
+          assocation_hash_args.each_pair do |key, value|
+            return value if key.value == :class_name && value.str_type?
+          end
+          nil
+        end
+
+        def in_enforced_api_file?
+          file_path = processed_source.path
+          return false unless file_path.include?(apis_path)
+          return false if in_disabled_api?(file_path)
+
+          true
+        end
+
+        def in_enforced_controller_file?
+          file_path = processed_source.path
+          return false unless file_path.include?(controllers_path)
+          return false if in_disabled_controller?(file_path)
+
+          true
+        end
+
+        def in_disabled_api?(file_path)
+          disabled_apis.any? do |e|
+            file_path.include?(File.join(apis_path, e))
+          end
+        end
+
+        def in_disabled_controller?(file_path)
+          disabled_controllers.any? do |e|
+            file_path.include?(File.join(controllers_path, e))
+          end
+        end
+
+        def global_model_const?(const_node)
+          # Remove leading `::`, if any.
+          class_name = const_node.source.sub(/^:*/, '')
+          global_model?(class_name)
+        end
+
+        # class_name is e.g. "FooGlobalModelNamespace::BarModel"
+        def global_model?(class_name)
+          global_model_names.include?(class_name)
+        end
+
+        def child_of_const?(node)
+          node.parent.const_type?
+        end
+
+        def global_models_path
+          path = cop_config['ModelsPath']
+          path += '/' unless path.end_with?('/')
+          path
+        end
+
+        def apis_path
+          cop_config['ApisPath']
+        end
+
+        def controllers_path
+          cop_config['ControllersPath']
+        end
+
+        def disabled_apis
+          raw = cop_config['DisabledApis'] || []
+          raw.map do |e|
+            ActiveSupport::Inflector.underscore(e)
+          end
+        end
+
+        def disabled_controllers
+          raw = cop_config['DisabledControllers'] || []
+          raw.map do |e|
+            ActiveSupport::Inflector.underscore(e)
+          end
+        end
+
+        def allowed_global_models
+          cop_config['AllowedModels'] || []
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rails/model_access_from_api_controller.rb
+++ b/lib/rubocop/cop/rails/model_access_from_api_controller.rb
@@ -115,7 +115,7 @@ module RuboCop
 
         def in_enforced_api_file?
           file_path = processed_source.path
-          return false unless file_path.include?(apis_path)
+          return false unless file_path.include?(apis_or_controllers_path('api'))
           return false if in_disabled_api?(file_path)
 
           true
@@ -123,7 +123,7 @@ module RuboCop
 
         def in_enforced_controller_file?
           file_path = processed_source.path
-          return false unless file_path.include?(controllers_path)
+          return false unless file_path.include?(apis_or_controllers_path('controller'))
           return false if in_disabled_controller?(file_path)
 
           true
@@ -131,13 +131,13 @@ module RuboCop
 
         def in_disabled_api?(file_path)
           disabled_apis.any? do |e|
-            file_path.include?(File.join(apis_path, e))
+            file_path.include?(File.join(apis_or_controllers_path('api'), e))
           end
         end
 
         def in_disabled_controller?(file_path)
           disabled_controllers.any? do |e|
-            file_path.include?(File.join(controllers_path, e))
+            file_path.include?(File.join(apis_or_controllers_path('controller'), e))
           end
         end
 
@@ -162,12 +162,8 @@ module RuboCop
           path
         end
 
-        def apis_path
-          cop_config['ApisPath']
-        end
-
-        def controllers_path
-          cop_config['ControllersPath']
+        def apis_or_controllers_path(which_one)
+          which_one == 'api' ? cop_config['ApisPath'] : cop_config['ControllersPath']
         end
 
         def disabled_apis

--- a/lib/rubocop/cop/rails/model_access_from_api_controller.rb
+++ b/lib/rubocop/cop/rails/model_access_from_api_controller.rb
@@ -6,13 +6,13 @@ require 'digest/sha1'
 module RuboCop
   module Cop
     module Rails
-      # This cop checks for engines reaching directly into app/ models.
+      # This cop checks for API or Controllers classes reaching directly into app/ models.
       #
       # Inspired by:
       # https://flexport.engineering/isolating-rails-engines-with-rubocop-210feaba3164
       # https://github.com/flexport/rubocop-flexport/pull/5/files
       #
-      # With an ActiveRecord object, engine code can perform arbitrary
+      # With an Model/ActiveRecord object, Api or Controller code can perform arbitrary
       # reads and arbitrary writes to models located in the main `app/`
       # directory. This cop helps isolate Rails Api code to ensure
       # that modular boundaries are respected.

--- a/lib/rubocop/petal/version.rb
+++ b/lib/rubocop/petal/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Petal
-    VERSION = '0.8.0'
+    VERSION = '0.9.0'
   end
 end

--- a/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
+++ b/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails::ModelAccessFromApiController, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new(
+      'Rails/ModelAccessFromApiController' => {
+        'DisabledApis' => %w[
+          fake_disabled_api
+          FakeDisabledApiCamel
+        ], 'DisabledControllers' => %w[
+             fake_disabled_controller
+             FakeDisabledControllerCamel
+           ],
+        'ApisPath' => 'app/api/',
+        'ControllersPath' => 'app/controllers/',
+        'ModelsPath' => 'app/models/',
+        'AllowedModels' => ['WhitelistedModel']
+      }
+    )
+  end
+
+  let(:api_file) { '/root/api/my_api/app/file.rb' }
+
+  before do
+    allow(Dir).to(
+      receive(:[])
+        .with('app/models/**/*.rb')
+        .and_return(%w[app/models/some_model.rb app/models/nested/global_model.rb])
+    )
+  end
+
+  context 'no violation' do
+    describe 'when disabled api' do
+      let(:disabled_api_file) do
+        '/root/apis/fake_disabled_api/app/file.rb'
+      end
+      let(:source) do
+        <<~RUBY
+          SomeModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, disabled_api_file)
+      end
+    end
+
+    describe 'disabled api camel case' do
+      let(:disabled_api_file) do
+        '/root/apis/fake_disabled_api_camel/app/file.rb'
+      end
+      let(:source) do
+        <<~RUBY
+          SomeModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, disabled_api_file)
+      end
+    end
+
+    describe 'just accessing a const' do
+      let(:source) do
+        <<~RUBY
+          a = SomeModel::SOME_CONST
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, api_file)
+      end
+    end
+
+    describe 'file in app/ outside api' do
+      let(:non_api_file) { '/root/app/file.rb' }
+      let(:source) do
+        <<~RUBY
+          SomeModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, non_api_file)
+      end
+    end
+
+    describe 'with whitelisted model' do
+      let(:source) do
+        <<~RUBY
+          WhitelistedModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, api_file)
+      end
+    end
+
+    describe 'association to model in app/' do
+      let(:non_api_file) { '/root/app/models/bar.rb' }
+      let(:source) do
+        <<~RUBY
+          class Bar < ApplicationModel
+            has_one :some_model, class_name: "SomeModel", inverse_of: :bar
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, non_api_file)
+      end
+    end
+
+    describe 'association to other api model' do
+      let(:source) do
+        <<~RUBY
+          class MyApi::Foo < ApplicationModel
+            has_one :bar, class_name: "SomeOtherApi::Bar", inverse_of: :foo
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, api_file)
+      end
+    end
+  end
+
+  context 'violation' do
+    describe 'when access of model from api' do
+      let(:source) do
+        <<~RUBY
+          SomeModel.find(123)
+          ^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source, api_file)
+      end
+    end
+
+    describe 'association to model' do
+      let(:source) do
+        <<~RUBY
+          class MyApi::Foo < ApplicationModel
+            has_one :some_model, class_name: "SomeModel", inverse_of: :foo
+                                                    ^^^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
+          end
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source, api_file)
+      end
+    end
+
+    context 'nested model' do
+      describe 'when access of model from engine' do
+        let(:source) do
+          <<~RUBY
+            Nested::SomeModel.find(123)
+            ^^^^^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
+          RUBY
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, api_file)
+        end
+      end
+
+      describe 'association to model' do
+        let(:source) do
+          <<~RUBY
+            class MyApi::FooModel < ApplicationModel
+              has_one :nested_model, class_name: "Nested::SomeModel", inverse_of: :foo
+                                                        ^^^^^^^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
+            end
+          RUBY
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, api_file)
+        end
+      end
+    end
+  end
+
+  describe '#external_dependency_checksum' do
+    it 'differs based on contents of app/models dir' do
+      old_checksum = cop.external_dependency_checksum
+      allow(Dir).to(
+        receive(:[])
+          .with('app/models/**/*.rb')
+          .and_return(['app/models/nested/model.rb'])
+      )
+      new_checksum = cop.external_dependency_checksum
+      expect(new_checksum).not_to equal(old_checksum)
+    end
+  end
+end

--- a/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
+++ b/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::Rails::ModelAccessFromApiController, :config do
     )
   end
 
-  let(:api_file) { '/root/api/my_api/app/file.rb' }
+  let(:api_file) { '/root/app/api/file.rb' }
 
   before do
     allow(Dir).to(
@@ -133,58 +133,13 @@ RSpec.describe RuboCop::Cop::Rails::ModelAccessFromApiController, :config do
     describe 'when access of model from api' do
       let(:source) do
         <<~RUBY
-          SomeModel.find(123)
-          ^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
+          SomeModel.new
+          ^^^^^^^^^ Direct access of model from within Rails Api or Controller.
         RUBY
       end
 
       it 'adds an offense' do
         expect_offense(source, api_file)
-      end
-    end
-
-    describe 'association to model' do
-      let(:source) do
-        <<~RUBY
-          class MyApi::Foo < ApplicationModel
-            has_one :some_model, class_name: "SomeModel", inverse_of: :foo
-                                                    ^^^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
-          end
-        RUBY
-      end
-
-      it 'adds an offense' do
-        expect_offense(source, api_file)
-      end
-    end
-
-    context 'nested model' do
-      describe 'when access of model from engine' do
-        let(:source) do
-          <<~RUBY
-            Nested::SomeModel.find(123)
-            ^^^^^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
-          RUBY
-        end
-
-        it 'adds an offense' do
-          expect_offense(source, api_file)
-        end
-      end
-
-      describe 'association to model' do
-        let(:source) do
-          <<~RUBY
-            class MyApi::FooModel < ApplicationModel
-              has_one :nested_model, class_name: "Nested::SomeModel", inverse_of: :foo
-                                                        ^^^^^^^^^^^^^^^^^^^^^ Direct access of model from within Rails Api.
-            end
-          RUBY
-        end
-
-        it 'adds an offense' do
-          expect_offense(source, api_file)
-        end
       end
     end
   end

--- a/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
+++ b/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe RuboCop::Cop::Rails::ModelAccessFromApiController, :config do
         'DisabledApis' => %w[
           fake_disabled_api
           FakeDisabledApiCamel
-        ], 'DisabledControllers' => %w[
-             fake_disabled_controller
-             FakeDisabledControllerCamel
-           ],
+        ],
+        'DisabledControllers' => %w[
+          fake_disabled_controller
+          FakeDisabledControllerCamel
+        ],
         'ApisPath' => 'app/api/',
         'ControllersPath' => 'app/controllers/',
         'ModelsPath' => 'app/models/',

--- a/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
+++ b/spec/rubocop/cop/rails/model_access_from_api_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::Rails::ModelAccessFromApiController, :config do
     )
   end
 
-  context 'no violation' do
+  context 'with no violation' do
     describe 'when disabled api' do
       let(:disabled_api_file) do
         '/root/apis/fake_disabled_api/app/file.rb'
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::Rails::ModelAccessFromApiController, :config do
     end
   end
 
-  context 'violation' do
+  context 'with violation' do
     describe 'when access of model from api' do
       let(:source) do
         <<~RUBY


### PR DESCRIPTION
## What's the PR about

[SEME-1955-Rubocop-for-micro-service](https://petalmd.atlassian.net/browse/SEME-1955)

## Work done

Implementation of new cop to prevent direct access of model from within Rails Api or Controller.

## How to test
-Any GRAPE API or Controller class shouldn’t be able to instantiate a model class
-In your rails project `.rubocop.yml` file, place the following new rule
```
Rails/ModelAccessFromApiController:
  Enabled: true
  DisabledApis: []        ** use this list to specify which api class is allowed to bypass the cop
  DisabledControllers: [] ** use this list to specify which controller class is allowed to bypass the cop
  AllowedModels: []       ** use this list to specify which model is allowed to bypass the cop
```

-And if changes the default classes path, it is necessary also to specify it
```
  ControllersPath: app/controllers/
  ApisPath: app/api/
  ModelsPath: app/models/
```



The image below represents an example of how the cop acts to prevent this scenario.

![Screenshot 2023-05-01 at 3 20 33 PM](https://user-images.githubusercontent.com/118772370/235518322-9a59630c-9b2d-4b54-be07-a277ce46fd02.png)




