### PR TITLE
Add Migration/AlwaysBulkChangeTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # main
 
+* Added cop `Migration/AlwaysBulkChangeTable` ([#46](https://github.com/petalmd/rubocop-petal/pull/46))
+
 # v1.0.0 (2023-05-15)
 
 * Unified cops to be reused by others projects. ([#41](https://github.com/petalmd/rubocop-petal/pull/41))

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,12 @@ Grape/PreferNamespace:
   Include:
     - app/api/**/*
 
+Migration/AlwaysBulkChangeTable:
+  Description: 'Suggest to always use `bulk: true` when using `change_table`.'
+  Enabled: true
+  Include:
+    - db/migrate/**
+
 Migration/ForeignKeyOption:
   Description: 'Specify the foreign key option to create the constraint.'
   Enabled: true

--- a/lib/rubocop/cop/migration/always_bulk_change_table.rb
+++ b/lib/rubocop/cop/migration/always_bulk_change_table.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Migration
+      # Using `bulk: true` with `change_table` is recommended.
+      # Without `bulk: true`, `change_table` generates multiple
+      # `ALTER TABLE` statements and the migration process will
+      # be duplicated.
+      #
+      # @bad
+      #   change_table :users do |t|
+      #     t.string :first_name
+      #     t.string :last_name
+      #   end
+      #
+      # @good
+      #  change_table :users, bulk: true do |t|
+      #    t.string :first_name
+      #    t.string :last_name
+      #  end
+      #
+      class AlwaysBulkChangeTable < Rails::BulkChangeTable
+        MSG = 'Add `bulk: true` when using change_table.'
+        RESTRICT_ON_SEND = %i[change_table].freeze
+
+        def on_send(node)
+          return unless node.command?(:change_table)
+
+          unless include_bulk_options?(node)
+            add_offense(node)
+            return
+          end
+
+          add_offense(node) unless bulk_options_true?(node)
+        end
+
+        def bulk_options_true?(node)
+          options = node.arguments[1]
+          options.each_pair do |key, value|
+            return true if key.value == :bulk && value.true_type?
+          end
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/migration/always_bulk_change_table_spec.rb
+++ b/spec/rubocop/cop/migration/always_bulk_change_table_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Migration::AlwaysBulkChangeTable, :config do
+  it 'registers an offense when not using bulk: true' do
+    expect_offense(<<~RUBY)
+      change_table :users do |t|
+      ^^^^^^^^^^^^^^^^^^^ Add `bulk: true` when using change_table.
+         t.string :name
+      end
+    RUBY
+
+    expect_offense(<<~RUBY)
+      change_table :users, bulk: false do |t|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add `bulk: true` when using change_table.
+         t.string :name
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using change_table and bulk true' do
+    expect_no_offenses(<<~RUBY)
+      change_table :users, bulk: true do |t|
+         t.string :name
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This cop: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsbulkchangetable doesn't really require to use bulk true. Bulk false is accepted for example. 

It is mainly use to find 

```
# bad
def change
  add_column :users, :name, :string, null: false
  add_column :users, :nickname, :string
end
```

It also not triggered on some methods.