### PR TITLE
Remove ActiveSupport usage delegate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,5 @@ inherit_gem:
 Naming/FileName:
   Exclude:
     - lib/rubocop-petal.rb
-Rails/Output:
-  Enabled: false
-Rails/RakeEnvironment:
+Rails:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # main
 
+* Remove usage of `delegate` from activesupport. ([#78](https://github.com/petalmd/rubocop-petal/pull/78)) 
+
 # v1.3.0 (2024-01-09)
 
 * Added autocorrection for `RSpec/MultipleExpectations`. 

--- a/lib/rubocop/cop/rspec/aggregate_examples/language.rb
+++ b/lib/rubocop/cop/rspec/aggregate_examples/language.rb
@@ -24,8 +24,8 @@ module RuboCop
               self.class.new(selectors + other.selectors)
             end
 
-            def include?(other)
-              selectors.include?(other)
+            def include?(selector)
+              selectors.include?(selector)
             end
 
             def block_pattern

--- a/lib/rubocop/cop/rspec/aggregate_examples/language.rb
+++ b/lib/rubocop/cop/rspec/aggregate_examples/language.rb
@@ -24,7 +24,9 @@ module RuboCop
               self.class.new(selectors + other.selectors)
             end
 
-            delegate :include?, to: :selectors
+            def include?(other)
+              selectors.include?(other)
+            end
 
             def block_pattern
               "(block #{send_pattern} ...)"


### PR DESCRIPTION
If activesupport is not loaded, running `AggregateExamples` may cause problem since it was using delegate from activesupport.

The delegate version was automaticly changed by Rubocop with a Rails cop (which I disabled in this PR) 

Orignal version: https://github.com/test-prof/test-prof/blob/02d8f355c158fb021e58ff1327d624a8299762b6/lib/test_prof/cops/rspec/language.rb#L26-L28

```
❯ be rubocop
undefined method `delegate' for RuboCop::Cop::RSpec::AggregateExamples::Language::SelectorSet:Class
Did you mean?  DelegateClass
/Users/jfbastien/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rubocop-petal-1.3.0/lib/rubocop/cop/rspec/aggregate_examples/language.rb:27:in `<class:SelectorSet>'
/Users/jfbastien/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rubocop-petal-1.3.0/lib/rubocop/cop/rspec/aggregate_examples/language.rb:14:in `<module:Language>'
```