### PR TITLE
Set `Rails/Date`, `AllowToTime` config to false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # main
 
+* Set `Rails/Date`, `AllowToTime` config to false.
 * Remove cop `RSpec/AuthenticatedAs`. ([#79](https://github.com/petalmd/rubocop-petal/pull/79))
 
 # v1.3.1 (2024-02-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # main
 
-* Set `Rails/Date`, `AllowToTime` config to false.
+* Set `Rails/Date`, `AllowToTime` config to false. ([#80](https://github.com/petalmd/rubocop-petal/pull/80))
 * Remove cop `RSpec/AuthenticatedAs`. ([#79](https://github.com/petalmd/rubocop-petal/pull/79))
 
 # v1.3.1 (2024-02-13)

--- a/config/base.yml
+++ b/config/base.yml
@@ -78,6 +78,8 @@ RSpec/StubbedMock:
 RSpec/DescribeClass:
   Exclude:
     - spec/integration/**/*.rb
+Rails/Date:
+  AllowToTime: false
 Rails/SaveBang:
   Enabled: true
 Rails/NotNullColumn:


### PR DESCRIPTION
`Date#to_time` Return the time with the timezone of the host/server.

So it may vary from an env to another.

`in_time_zone` should be use.

```ruby
> Date.current.to_time
"2024-03-12T00:00:00.000-04:00"

> Date.current.in_time_zone
Tue, 12 Mar 2024 00:00:00 UTC +00:00
```

https://docs.rubocop.org/rubocop-rails/cops_rails.html#allowtotime-false