### PR TITLE
DOPS-4867_RuboCop::Cop::Sidekiq::SymbolArgument -> hash literal with symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # main
+* Sidekiq/SymbolArgument now handles Arrays/Hashes with symbols and has an autocorrection ([#86](https://github.com/petalmd/rubocop-petal/pull/86))
 
 # v1.5.0 (2024-12-11)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -157,3 +157,4 @@ Sidekiq/PerformInline:
 Sidekiq/SymbolArgument:
   Description: "Prevent passing keywords arguments in worker's perform method"
   Enabled: true
+  SafeAutoCorrect: false

--- a/lib/rubocop/cop/sidekiq/const_argument.rb
+++ b/lib/rubocop/cop/sidekiq/const_argument.rb
@@ -25,8 +25,8 @@ module RuboCop
 
         include Helpers
 
-        MSG = 'Objects are not Sidekiq-serializable.'
-        MSG_SELF = '`self` is not Sidekiq-serializable.'
+        MSG = 'Objects are not native JSON types.'
+        MSG_SELF = '`self` is not a native JSON type.'
 
         def_node_matcher :initializer?, <<~PATTERN
           (send const :new)

--- a/lib/rubocop/cop/sidekiq/date_time_argument.rb
+++ b/lib/rubocop/cop/sidekiq/date_time_argument.rb
@@ -61,8 +61,8 @@ module RuboCop
 
         include Helpers
 
-        DURATION_MSG = 'Durations are not Sidekiq-serializable; use the integer instead.'
-        MSG = 'Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.'
+        DURATION_MSG = 'Durations are not native JSON types; use the integer instead.'
+        MSG = 'Date/Time objects are not native JSON types; convert to integers or strings instead.'
         ALLOWED_METHODS = %i[to_i to_s].freeze
 
         def_node_matcher :rational_literal?, <<~PATTERN

--- a/lib/rubocop/cop/sidekiq/helpers.rb
+++ b/lib/rubocop/cop/sidekiq/helpers.rb
@@ -59,8 +59,10 @@ module RuboCop
 
         def expand_arguments(arguments)
           arguments.flat_map do |argument|
-            if argument.array_type? || argument.hash_type?
+            if argument.array_type?
               expand_arguments(argument.values)
+            elsif argument.hash_type?
+              expand_arguments(argument.keys.concat(argument.values))
             else
               argument
             end

--- a/lib/rubocop/cop/sidekiq/helpers.rb
+++ b/lib/rubocop/cop/sidekiq/helpers.rb
@@ -62,7 +62,7 @@ module RuboCop
             if argument.array_type?
               expand_arguments(argument.values)
             elsif argument.hash_type?
-              expand_arguments(argument.keys.concat(argument.values))
+              expand_arguments(argument.pairs)
             else
               argument
             end

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -15,6 +15,12 @@ module RuboCop
       #
       #   # good
       #   MyWorker.perform_async('foo')
+      #
+      #   # bad
+      #   MyWorker.perform_async(foo: 1)
+      #
+      #   # good
+      #   MyWorker.perform_async({'foo' => 1})
       class SymbolArgument < Base
         include Helpers
 

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -22,13 +22,33 @@ module RuboCop
       #   # good
       #   MyWorker.perform_async({'foo' => 1})
       class SymbolArgument < Base
+        extend AutoCorrector
+
         include Helpers
 
         MSG = 'Symbols are not Sidekiq-serializable; use strings instead.'
 
         def on_send(node)
-          sidekiq_arguments(node).select(&:sym_type?).each do |argument|
-            add_offense(argument)
+          sidekiq_arguments(node).each do |argument|
+            if argument.sym_type?
+              add_offense(argument) do |corrector|
+                corrector.replace(argument, "'#{argument.value}'")
+              end
+            elsif argument.pair_type?
+              if argument.key.sym_type? && argument.value.sym_type?
+                add_offense(argument) do |corrector|
+                  corrector.replace(argument, "'#{argument.key.value}' => '#{argument.value.value}'")
+                end
+              elsif argument.key.sym_type?
+                add_offense(argument.key) do |corrector|
+                  corrector.replace(argument, "'#{argument.key.value}' => #{argument.value.value}")
+                end
+              elsif argument.value.sym_type?
+                add_offense(argument.value) do |corrector|
+                  corrector.replace(argument.value, "'#{argument.value.value}'")
+                end
+              end
+            end
           end
         end
       end

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   MyWorker.perform_async(:foo)
       #
       #   # good
-      #   MyWorker.perform_async('foo')
+      #   MyWorker.perform_async("foo")
       #
       #   # bad
       #   MyWorker.perform_async(%i(foo))
@@ -26,7 +26,7 @@ module RuboCop
       #   MyWorker.perform_async([:foo])
       #
       #   # good
-      #   MyWorker.perform_async(['foo']))
+      #   MyWorker.perform_async(["foo"]))
       #
       #   # bad
       #   MyWorker.perform_async(foo: 1)
@@ -38,13 +38,13 @@ module RuboCop
       #   MyWorker.perform_async('foo' => :baz)
       #
       #   # good
-      #   MyWorker.perform_async('foo' => 'baz')
+      #   MyWorker.perform_async('foo' => "baz")
       #
       #   # bad
       #   MyWorker.perform_async('foo' => [:bar]
       #
       #   # good
-      #   MyWorker.perform_async('foo' => ['baz'])
+      #   MyWorker.perform_async('foo' => ["baz"])
       #
       #   # bad
       #   MyWorker.perform_async('foo' => %i(baz)
@@ -62,7 +62,7 @@ module RuboCop
       #   MyWorker.perform_async('foo' => { bar: [:baz]) })
       #
       #   # good
-      #   MyWorker.perform_async('foo' => { bar: ['baz'] })
+      #   MyWorker.perform_async('foo' => { bar: ["baz"] })
       #
       class SymbolArgument < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         include Helpers
 
-        MSG = 'Symbols are not Sidekiq-serializable; use strings instead.'
+        MSG = 'Symbols are not native JSON types; use strings instead.'
 
         def on_send(node)
           sidekiq_arguments(node)

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -21,6 +21,49 @@ module RuboCop
       #
       #   # good
       #   MyWorker.perform_async(%w(foo))
+      #
+      #   # bad
+      #   MyWorker.perform_async([:foo])
+      #
+      #   # good
+      #   MyWorker.perform_async(['foo']))
+      #
+      #   # bad
+      #   MyWorker.perform_async(foo: 1)
+      #
+      #   # good
+      #   MyWorker.perform_async('foo' => 1)
+      #
+      #   # bad
+      #   MyWorker.perform_async('foo' => :baz)
+      #
+      #   # good
+      #   MyWorker.perform_async('foo' => 'baz')
+      #
+      #   # bad
+      #   MyWorker.perform_async('foo' => [:bar]
+      #
+      #   # good
+      #   MyWorker.perform_async('foo' => ['baz'])
+      #
+      #   # bad
+      #   MyWorker.perform_async('foo' => %i(baz)
+      #
+      #   # good
+      #   MyWorker.perform_async('foo' => %w(baz))
+      #
+      #   # bad
+      #   MyWorker.perform_async('foo' => { bar: %i(baz) })
+      #
+      #   # good
+      #   MyWorker.perform_async('foo' => { bar: %w(baz) })
+      #
+      #   # bad
+      #   MyWorker.perform_async('foo' => { bar: [:baz]) })
+      #
+      #   # good
+      #   MyWorker.perform_async('foo' => { bar: ['baz'] })
+      #
       class SymbolArgument < Base
         extend AutoCorrector
 
@@ -44,9 +87,15 @@ module RuboCop
         private
 
         def node_contains_symbol?(node)
-          node.sym_type? ||
-            (node.array_type? && node.percent_literal?(:symbol)) ||
-            (node.pair_type? && (node.key.sym_type? || node.value.sym_type?))
+          node.sym_type? || symbol_percent_literal?(node) || pair_with_symbol?(node)
+        end
+
+        def symbol_percent_literal?(node)
+          node.array_type? && node.percent_literal?(:symbol)
+        end
+
+        def pair_with_symbol?(node)
+          node.pair_type? && (node.key.sym_type? || node.value.sym_type?)
         end
 
         def offense_data(node)

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -64,7 +64,9 @@ module RuboCop
           return unless argument.key.sym_type?
 
           add_offense(argument.key) do |corrector|
-            corrector.replace(argument, "'#{argument.key.value}' => #{argument.value.value}")
+            value = argument.value
+            corrected_value = value.lvar_type? ? value.source : value.value
+            corrector.replace(argument, "'#{argument.key.value}' => #{corrected_value}")
           end
         end
 

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -65,7 +65,7 @@ module RuboCop
 
           add_offense(argument.key) do |corrector|
             value = argument.value
-            corrected_value = value.lvar_type? ? value.source : value.value
+            corrected_value = value.lvar_type? || value.send_type? ? value.source : value.value
             corrector.replace(argument, "'#{argument.key.value}' => #{corrected_value}")
           end
         end

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -65,7 +65,8 @@ module RuboCop
 
           add_offense(argument.key) do |corrector|
             value = argument.value
-            corrected_value = value.lvar_type? || value.send_type? ? value.source : value.value
+            not_value_type = value.lvar_type? || value.send_type? || value.block_type?
+            corrected_value = not_value_type ? value.source : value.value
             corrector.replace(argument, "'#{argument.key.value}' => #{corrected_value}")
           end
         end

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -65,9 +65,7 @@ module RuboCop
 
           add_offense(argument.key) do |corrector|
             value = argument.value
-            source_type = value.lvar_type? || value.call_type? || value.block_type? || value.boolean_type?
-            corrected_value = source_type ? value.source : value.value
-            corrector.replace(argument, "'#{argument.key.value}' => #{corrected_value}")
+            corrector.replace(argument, "'#{argument.key.value}' => #{value.source}")
           end
         end
 

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -64,8 +64,7 @@ module RuboCop
           return unless argument.key.sym_type?
 
           add_offense(argument.key) do |corrector|
-            value = argument.value
-            corrector.replace(argument, "'#{argument.key.value}' => #{value.source}")
+            corrector.replace(argument, "'#{argument.key.value}' => #{argument.value.source}")
           end
         end
 

--- a/lib/rubocop/cop/sidekiq/symbol_argument.rb
+++ b/lib/rubocop/cop/sidekiq/symbol_argument.rb
@@ -65,8 +65,8 @@ module RuboCop
 
           add_offense(argument.key) do |corrector|
             value = argument.value
-            not_value_type = value.lvar_type? || value.send_type? || value.block_type?
-            corrected_value = not_value_type ? value.source : value.value
+            source_type = value.lvar_type? || value.call_type? || value.block_type? || value.boolean_type?
+            corrected_value = source_type ? value.source : value.value
             corrector.replace(argument, "'#{argument.key.value}' => #{corrected_value}")
           end
         end

--- a/spec/rubocop/cop/sidekiq/const_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/const_argument_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::ConstArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(1, {'abc' => 3}, MyClass, 1, {'abc' => 3})
-                                                  ^^^^^^^ Sidekiq/ConstArgument: Objects are not Sidekiq-serializable.
+                                                  ^^^^^^^ Sidekiq/ConstArgument: Objects are not native JSON types.
         RUBY
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::ConstArgument, :config do
         expect_offense(<<~RUBY)
           at = Time.zone.now.iso8601
           MyWorker.perform_at(at, 1, {'abc' => 3}, MyClass, 1, {'abc' => 3})
-                                                   ^^^^^^^ Sidekiq/ConstArgument: Objects are not Sidekiq-serializable.
+                                                   ^^^^^^^ Sidekiq/ConstArgument: Objects are not native JSON types.
         RUBY
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::ConstArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.seconds, 1, {'abc' => 3}, MyClass, 1, {'abc' => 3})
-                                                          ^^^^^^^ Sidekiq/ConstArgument: Objects are not Sidekiq-serializable.
+                                                          ^^^^^^^ Sidekiq/ConstArgument: Objects are not native JSON types.
         RUBY
       end
     end

--- a/spec/rubocop/cop/sidekiq/date_time_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/date_time_argument_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(Time.zone.now)
-                                 ^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                 ^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
 
       it 'registers an offense on Time.current' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(Time.current)
-                                 ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                 ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(Date.current)
-                                 ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                 ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(Time.now)
-                                 ^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                 ^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(DateTime.new(2001,2,3,4,5,6))
-                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async(1.hour)
-                                 ^^^^^^ Sidekiq/DateTimeArgument: Durations are not Sidekiq-serializable; use the integer instead.
+                                 ^^^^^^ Sidekiq/DateTimeArgument: Durations are not native JSON types; use the integer instead.
         RUBY
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, Time.zone.now)
-                                             ^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                             ^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, Date.current)
-                                             ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                             ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, Time.now)
-                                             ^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                             ^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, DateTime.new(2001,2,3,4,5,6))
-                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, 1.hour)
-                                             ^^^^^^ Sidekiq/DateTimeArgument: Durations are not Sidekiq-serializable; use the integer instead.
+                                             ^^^^^^ Sidekiq/DateTimeArgument: Durations are not native JSON types; use the integer instead.
         RUBY
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.minutes, Time.zone.now)
-                                         ^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                         ^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.minutes, Date.current)
-                                         ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                         ^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.minutes, Time.now)
-                                         ^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                         ^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.minutes, DateTime.new(2001,2,3,4,5,6))
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not Sidekiq-serializable; convert to integers or strings instead.
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/DateTimeArgument: Date/Time objects are not native JSON types; convert to integers or strings instead.
         RUBY
       end
     end
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::DateTimeArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(5.minutes, 1.hour)
-                                         ^^^^^^ Sidekiq/DateTimeArgument: Durations are not Sidekiq-serializable; use the integer instead.
+                                         ^^^^^^ Sidekiq/DateTimeArgument: Durations are not native JSON types; use the integer instead.
         RUBY
       end
     end

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -12,6 +12,33 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         RUBY
       end
     end
+
+    describe 'when called with a hash that contains a key symbol' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          MyWorker.perform_async('a', 1, foo: 1)
+                                         ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+      end
+    end
+
+    describe 'when called with a hash that contains a value symbol' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          MyWorker.perform_async('a', 1, 'bar' => :baz)
+                                                  ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+      end
+    end
+
+    describe 'when called with a hash that contains a  symbol' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          MyWorker.perform_async('a', 1, { 'bar' => :baz }, b)
+                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+      end
+    end
   end
 
   describe '#perform_at' do

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -17,37 +17,53 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
       end
     end
 
-    describe 'when called with a hash that contains a key symbol' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          MyWorker.perform_async('a', 1, foo: 1)
-                                         ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-        RUBY
+    context 'when argument is a Hash' do
+      context 'when key is a symbol' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, foo: 1)
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          MyWorker.perform_async('a', 1, 'foo' => 1)
-        RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'foo' => 1)
+          RUBY
+        end
+
+        context 'when value is a var' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              a = 1
+              MyWorker.perform_async('a', 1, bar: a)
+                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+            RUBY
+            expect_correction(<<~RUBY)
+              a = 1
+              MyWorker.perform_async('a', 1, 'bar' => a)
+            RUBY
+          end
+        end
       end
-    end
 
-    describe 'when called with a hash that contains a value symbol' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          MyWorker.perform_async('a', 1, 'bar' => :baz)
-                                                  ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-        RUBY
+      context 'when value is a symbol' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => :baz)
+                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+        end
       end
-    end
 
-    describe 'when called with a hash that contains a key and a value symbol' do
-      it 'registers an offense' do
-        expect_offense(<<~RUBY)
-          MyWorker.perform_async('a', 1, bar: :baz)
-                                         ^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-        RUBY
-        expect_correction(<<~RUBY)
-          MyWorker.perform_async('a', 1, 'bar' => 'baz')
-        RUBY
+      context 'when key/value are symbols' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, bar: :baz)
+                                           ^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => 'baz')
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
             RUBY
           end
         end
+
+        context 'when value is a block' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              my_service = MyService.new('a')
+              MyWorker.perform_async('a', 1, bar: my_service.call('b'))
+                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+            RUBY
+            expect_correction(<<~RUBY)
+              my_service = MyService.new('a')
+              MyWorker.perform_async('a', 1, 'bar' => my_service.call('b'))
+            RUBY
+          end
+        end
       end
 
       context 'when value is a symbol' do

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
             RUBY
           end
         end
+
+        context 'when value is a function' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              MyWorker.perform_async('a', 1, bar: 1.hour)
+                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+            RUBY
+            expect_correction(<<~RUBY)
+              MyWorker.perform_async('a', 1, 'bar' => 1.hour)
+            RUBY
+          end
+        end
       end
 
       context 'when value is a symbol' do

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
             MyWorker.perform_async('a', 1, 'bar' => :baz)
                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
           RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => 'baz')
+          RUBY
         end
       end
 

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           MyWorker.perform_async('a', 1, :foo)
                                          ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
         RUBY
+
+        expect_correction(<<~RUBY)
+          MyWorker.perform_async('a', 1, 'foo')
+        RUBY
       end
     end
 
@@ -18,6 +22,10 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         expect_offense(<<~RUBY)
           MyWorker.perform_async('a', 1, foo: 1)
                                          ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MyWorker.perform_async('a', 1, 'foo' => 1)
         RUBY
       end
     end
@@ -31,11 +39,14 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
       end
     end
 
-    describe 'when called with a hash that contains a  symbol' do
+    describe 'when called with a hash that contains a key and a value symbol' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
-          MyWorker.perform_async('a', 1, { 'bar' => :baz }, b)
-                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          MyWorker.perform_async('a', 1, bar: :baz)
+                                         ^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+        expect_correction(<<~RUBY)
+          MyWorker.perform_async('a', 1, 'bar' => 'baz')
         RUBY
       end
     end

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
   let(:config) { RuboCop::Config.new }
 
   describe '#perform_async' do
-    describe 'when called with a symbol' do
+    context 'when called with a symbol' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async('a', 1, :foo)
@@ -12,12 +12,93 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          MyWorker.perform_async('a', 1, 'foo')
+          MyWorker.perform_async('a', 1, "foo")
         RUBY
       end
     end
 
-    context 'when argument is a Hash' do
+    context 'when called with an array' do
+      context 'when array has no symbols' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo'])
+          RUBY
+        end
+      end
+
+      context 'when array has a symbol' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo', :bar])
+                                                   ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo', "bar"])
+          RUBY
+        end
+      end
+
+      context 'when array has a symbol percent literal' do
+        context 'when symbol' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              MyWorker.perform_async('a', 1, ['foo', %i(bar baz)])
+                                                     ^^^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+            RUBY
+            expect_correction(<<~RUBY)
+              MyWorker.perform_async('a', 1, ['foo', %w(bar baz)])
+            RUBY
+          end
+        end
+
+        context 'when string' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              MyWorker.perform_async('a', 1, ['foo', %w(bar baz)])
+            RUBY
+          end
+        end
+      end
+
+      context 'when array has an array of symbols' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo', [:bar]])
+                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo', ["bar"]])
+          RUBY
+        end
+      end
+
+      context 'when array has a hash with symbols' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo', { bar: 'baz' }])
+                                                     ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, ['foo', { "bar" => 'baz' }])
+          RUBY
+        end
+      end
+    end
+
+    context 'when called with an percent literal' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          MyWorker.perform_async('a', 1, %i(foo bar))
+                                         ^^^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          MyWorker.perform_async('a', 1, %w(foo bar))
+        RUBY
+      end
+    end
+
+    context 'when called with a hash' do
       context 'when key is a symbol' do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
@@ -26,60 +107,60 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           RUBY
 
           expect_correction(<<~RUBY)
-            MyWorker.perform_async('a', 1, 'foo' => 1)
+            MyWorker.perform_async('a', 1, "foo" => 1)
           RUBY
         end
+      end
 
-        context 'when value is a var type' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              a = 1
-              MyWorker.perform_async('a', 1, bar: a)
-                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-            RUBY
-            expect_correction(<<~RUBY)
-              a = 1
-              MyWorker.perform_async('a', 1, 'bar' => a)
-            RUBY
-          end
+      context 'when value is a variable' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            a = 1
+            MyWorker.perform_async('a', 1, bar: a)
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            a = 1
+            MyWorker.perform_async('a', 1, "bar" => a)
+          RUBY
         end
+      end
 
-        context 'when value is a function type' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              MyWorker.perform_async('a', 1, bar: 1.hour)
-                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-            RUBY
-            expect_correction(<<~RUBY)
-              MyWorker.perform_async('a', 1, 'bar' => 1.hour)
-            RUBY
-          end
+      context 'when value is a function' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, bar: 1.hour)
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, "bar" => 1.hour)
+          RUBY
         end
+      end
 
-        context 'when value is a block type' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              my_service = MyService.new('a')
-              MyWorker.perform_async('a', 1, bar: my_service.call('b'))
-                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-            RUBY
-            expect_correction(<<~RUBY)
-              my_service = MyService.new('a')
-              MyWorker.perform_async('a', 1, 'bar' => my_service.call('b'))
-            RUBY
-          end
+      context 'when value is a block type' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            my_service = MyService.new('a')
+            MyWorker.perform_async('a', 1, bar: my_service.call('b'))
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            my_service = MyService.new('a')
+            MyWorker.perform_async('a', 1, "bar" => my_service.call('b'))
+          RUBY
         end
+      end
 
-        context 'when value is a boolean type' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              MyWorker.perform_async('a', 1, bar: true)
-                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
-            RUBY
-            expect_correction(<<~RUBY)
-              MyWorker.perform_async('a', 1, 'bar' => true)
-            RUBY
-          end
+      context 'when value is a boolean type' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, bar: true)
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, "bar" => true)
+          RUBY
         end
       end
 
@@ -90,7 +171,43 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
-            MyWorker.perform_async('a', 1, 'bar' => 'baz')
+            MyWorker.perform_async('a', 1, 'bar' => "baz")
+          RUBY
+        end
+      end
+
+      context 'when value is a percent literal' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => %i(baz))
+                                                    ^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => %w(baz))
+          RUBY
+        end
+      end
+
+      context 'when value is a an array' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => [:baz])
+                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'bar' => ["baz"])
+          RUBY
+        end
+      end
+
+      context 'when value is a another hash' do
+        it 'registers an offense' do
+          expect_offense(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'foo' => { 'bar' => %i(baz) })
+                                                               ^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+          RUBY
+          expect_correction(<<~RUBY)
+            MyWorker.perform_async('a', 1, 'foo' => { 'bar' => %w(baz) })
           RUBY
         end
       end
@@ -102,7 +219,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
                                            ^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
-            MyWorker.perform_async('a', 1, 'bar' => 'baz')
+            MyWorker.perform_async('a', 1, "bar" => "baz")
           RUBY
         end
       end
@@ -110,22 +227,28 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
   end
 
   describe '#perform_at' do
-    describe 'when called with a symbol' do
+    context 'when called with a symbol' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, 'a', 1, :foo)
                                                      ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+        expect_correction(<<~RUBY)
+          MyWorker.perform_at(Time.zone.now, 'a', 1, "foo")
         RUBY
       end
     end
   end
 
   describe '#perform_in' do
-    describe 'when called with a symbol' do
+    context 'when called with a symbol' do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.minutes, 'a', 1, :foo)
                                                  ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+        RUBY
+        expect_correction(<<~RUBY)
+          MyWorker.perform_in(5.minutes, 'a', 1, "foo")
         RUBY
       end
     end

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           RUBY
         end
 
-        context 'when value is a var' do
+        context 'when value is a var type' do
           it 'registers an offense' do
             expect_offense(<<~RUBY)
               a = 1
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           end
         end
 
-        context 'when value is a function' do
+        context 'when value is a function type' do
           it 'registers an offense' do
             expect_offense(<<~RUBY)
               MyWorker.perform_async('a', 1, bar: 1.hour)
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           end
         end
 
-        context 'when value is a block' do
+        context 'when value is a block type' do
           it 'registers an offense' do
             expect_offense(<<~RUBY)
               my_service = MyService.new('a')
@@ -66,6 +66,18 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
             expect_correction(<<~RUBY)
               my_service = MyService.new('a')
               MyWorker.perform_async('a', 1, 'bar' => my_service.call('b'))
+            RUBY
+          end
+        end
+
+        context 'when value is a boolean type' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY)
+              MyWorker.perform_async('a', 1, bar: true)
+                                             ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+            RUBY
+            expect_correction(<<~RUBY)
+              MyWorker.perform_async('a', 1, 'bar' => true)
             RUBY
           end
         end

--- a/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
+++ b/spec/rubocop/cop/sidekiq/symbol_argument_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async('a', 1, :foo)
-                                         ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                         ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, ['foo', :bar])
-                                                   ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                   ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, ['foo', "bar"])
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           it 'registers an offense' do
             expect_offense(<<~RUBY)
               MyWorker.perform_async('a', 1, ['foo', %i(bar baz)])
-                                                     ^^^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                     ^^^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
             RUBY
             expect_correction(<<~RUBY)
               MyWorker.perform_async('a', 1, ['foo', %w(bar baz)])
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, ['foo', [:bar]])
-                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, ['foo', ["bar"]])
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, ['foo', { bar: 'baz' }])
-                                                     ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                     ^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, ['foo', { "bar" => 'baz' }])
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_async('a', 1, %i(foo bar))
-                                         ^^^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                         ^^^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
         RUBY
 
         expect_correction(<<~RUBY)
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, foo: 1)
-                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
 
           expect_correction(<<~RUBY)
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           expect_offense(<<~RUBY)
             a = 1
             MyWorker.perform_async('a', 1, bar: a)
-                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             a = 1
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, bar: 1.hour)
-                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, "bar" => 1.hour)
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
           expect_offense(<<~RUBY)
             my_service = MyService.new('a')
             MyWorker.perform_async('a', 1, bar: my_service.call('b'))
-                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             my_service = MyService.new('a')
@@ -156,7 +156,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, bar: true)
-                                           ^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                           ^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, "bar" => true)
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, 'bar' => :baz)
-                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                    ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, 'bar' => "baz")
@@ -180,7 +180,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, 'bar' => %i(baz))
-                                                    ^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                    ^^^^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, 'bar' => %w(baz))
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, 'bar' => [:baz])
-                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, 'bar' => ["baz"])
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, 'foo' => { 'bar' => %i(baz) })
-                                                               ^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                               ^^^^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, 'foo' => { 'bar' => %w(baz) })
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
         it 'registers an offense' do
           expect_offense(<<~RUBY)
             MyWorker.perform_async('a', 1, bar: :baz)
-                                           ^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                           ^^^^^^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
           RUBY
           expect_correction(<<~RUBY)
             MyWorker.perform_async('a', 1, "bar" => "baz")
@@ -231,7 +231,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, 'a', 1, :foo)
-                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                     ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
         RUBY
         expect_correction(<<~RUBY)
           MyWorker.perform_at(Time.zone.now, 'a', 1, "foo")
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::Sidekiq::SymbolArgument, :config do
       it 'registers an offense' do
         expect_offense(<<~RUBY)
           MyWorker.perform_in(5.minutes, 'a', 1, :foo)
-                                                 ^^^^ Sidekiq/SymbolArgument: Symbols are not Sidekiq-serializable; use strings instead.
+                                                 ^^^^ Sidekiq/SymbolArgument: Symbols are not native JSON types; use strings instead.
         RUBY
         expect_correction(<<~RUBY)
           MyWorker.perform_in(5.minutes, 'a', 1, "foo")


### PR DESCRIPTION
This cop will now be able to catch any Sidekiq worker's arguments that contains a literal hash with symbols. I've also added an autocorrector and I've changed the message from `Sidekiq-serializable` to `native JSON types`.