### PR TITLE
Add RSpec/ChewyStrategy cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -60,9 +60,10 @@ RSpec/AggregateExamples:
     - validates_exclusion_of
 
 RSpec/ChewyStrategy:
-  Description: 'TODO: Write a description of the cop.'
-  Enabled: pending
-  VersionAdded: '<<next>>'
+  Description: 'Prevent using Chewy strategy in tests.'
+  Enabled: true
+  Include:
+    - spec/**/*
 
 RSpec/CreateListMax:
   Description: 'Prevent creating to most records with `FactoryBot.create_list`.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -59,6 +59,11 @@ RSpec/AggregateExamples:
     - validate_inclusion_of
     - validates_exclusion_of
 
+RSpec/ChewyStrategy:
+  Description: 'TODO: Write a description of the cop.'
+  Enabled: pending
+  VersionAdded: '<<next>>'
+
 RSpec/CreateListMax:
   Description: 'Prevent creating to most records with `FactoryBot.create_list`.'
   Enabled: true

--- a/lib/rubocop/cop/rspec/chewy_strategy.rb
+++ b/lib/rubocop/cop/rspec/chewy_strategy.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # TODO: Write cop description and example of bad / good code. For every
+      # `SupportedStyle` and unique configuration, there needs to be examples.
+      # Examples must have valid Ruby syntax. Do not use upticks.
+      #
+      # @safety
+      #   Delete this section if the cop is not unsafe (`Safe: false` or
+      #   `SafeAutoCorrect: false`), or use it to explain how the cop is
+      #   unsafe.
+      #
+      # @example EnforcedStyle: bar (default)
+      #   # Description of the `bar` style.
+      #
+      #   # bad
+      #   bad_bar_method
+      #
+      #   # bad
+      #   bad_bar_method(args)
+      #
+      #   # good
+      #   good_bar_method
+      #
+      #   # good
+      #   good_bar_method(args)
+      #
+      # @example EnforcedStyle: foo
+      #   # Description of the `foo` style.
+      #
+      #   # bad
+      #   bad_foo_method
+      #
+      #   # bad
+      #   bad_foo_method(args)
+      #
+      #   # good
+      #   good_foo_method
+      #
+      #   # good
+      #   good_foo_method(args)
+      #
+      class ChewyStrategy < Base
+        # TODO: Implement the cop in here.
+        #
+        # In many cases, you can use a node matcher for matching node pattern.
+        # See https://github.com/rubocop/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb
+        #
+        # For example
+        MSG = 'Use `#good_method` instead of `#bad_method`.'
+
+        # TODO: Don't call `on_send` unless the method name is in this list
+        # If you don't need `on_send` in the cop you created, remove it.
+        RESTRICT_ON_SEND = %i[bad_method].freeze
+
+        # @!method bad_method?(node)
+        def_node_matcher :bad_method?, <<~PATTERN
+          (send nil? :bad_method ...)
+        PATTERN
+
+        # Called on every `send` node (method call) while walking the AST.
+        # TODO: remove this method if inspecting `send` nodes is unneeded for your cop.
+        # By default, this is aliased to `on_csend` as well to handle method calls
+        # with safe navigation, remove the alias if this is unnecessary.
+        # If kept, ensure your tests cover safe navigation as well!
+        def on_send(node)
+          return unless bad_method?(node)
+
+          add_offense(node)
+        end
+        alias on_csend on_send
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/chewy_strategy.rb
+++ b/lib/rubocop/cop/rspec/chewy_strategy.rb
@@ -7,7 +7,7 @@ module RuboCop
       # Setting the strategy to atomic may try to import unnecessary data
       # for the test which result to a slower test suite.
       #
-      # @example 
+      # @example
       #   # bad
       #   let(:user) { Chewy.strategy(:atomic) { create(:user) } }
       #

--- a/lib/rubocop/cop/rspec/chewy_strategy.rb
+++ b/lib/rubocop/cop/rspec/chewy_strategy.rb
@@ -3,70 +3,29 @@
 module RuboCop
   module Cop
     module RSpec
-      # TODO: Write cop description and example of bad / good code. For every
-      # `SupportedStyle` and unique configuration, there needs to be examples.
-      # Examples must have valid Ruby syntax. Do not use upticks.
+      # Prevent to change the Chewy strategy in tests.
+      # Setting the strategy to atomic may try to import unnecessary data
+      # for the test which result to a slower test suite.
       #
-      # @safety
-      #   Delete this section if the cop is not unsafe (`Safe: false` or
-      #   `SafeAutoCorrect: false`), or use it to explain how the cop is
-      #   unsafe.
-      #
-      # @example EnforcedStyle: bar (default)
-      #   # Description of the `bar` style.
-      #
+      # @example 
       #   # bad
-      #   bad_bar_method
-      #
-      #   # bad
-      #   bad_bar_method(args)
+      #   let(:user) { Chewy.strategy(:atomic) { create(:user) } }
       #
       #   # good
-      #   good_bar_method
-      #
-      #   # good
-      #   good_bar_method(args)
-      #
-      # @example EnforcedStyle: foo
-      #   # Description of the `foo` style.
-      #
-      #   # bad
-      #   bad_foo_method
-      #
-      #   # bad
-      #   bad_foo_method(args)
-      #
-      #   # good
-      #   good_foo_method
-      #
-      #   # good
-      #   good_foo_method(args)
+      #   let(:user) { create(:user) }
+      #   before { UserIndex.import! user }
       #
       class ChewyStrategy < Base
-        # TODO: Implement the cop in here.
-        #
-        # In many cases, you can use a node matcher for matching node pattern.
-        # See https://github.com/rubocop/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb
-        #
-        # For example
-        MSG = 'Use `#good_method` instead of `#bad_method`.'
+        MSG = 'Do not use Chewy.strategy in tests. Import data explicitly instead.'
+        RESTRICT_ON_SEND = %i[strategy].freeze
 
-        # TODO: Don't call `on_send` unless the method name is in this list
-        # If you don't need `on_send` in the cop you created, remove it.
-        RESTRICT_ON_SEND = %i[bad_method].freeze
-
-        # @!method bad_method?(node)
-        def_node_matcher :bad_method?, <<~PATTERN
-          (send nil? :bad_method ...)
+        # @!method chewy_strategy?(node)
+        def_node_matcher :chewy_strategy?, <<~PATTERN
+          (send (const nil? :Chewy) :strategy ...)
         PATTERN
 
-        # Called on every `send` node (method call) while walking the AST.
-        # TODO: remove this method if inspecting `send` nodes is unneeded for your cop.
-        # By default, this is aliased to `on_csend` as well to handle method calls
-        # with safe navigation, remove the alias if this is unnecessary.
-        # If kept, ensure your tests cover safe navigation as well!
         def on_send(node)
-          return unless bad_method?(node)
+          return unless chewy_strategy?(node)
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/rspec/chewy_strategy_spec.rb
+++ b/spec/rubocop/cop/rspec/chewy_strategy_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChewyStrategy, :config do
       end
     RUBY
   end
-  
+
   it 'registers an offense when assigning Chewy.strategy to a variable' do
     expect_offense(<<~RUBY)
       before do

--- a/spec/rubocop/cop/rspec/chewy_strategy_spec.rb
+++ b/spec/rubocop/cop/rspec/chewy_strategy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::ChewyStrategy, :config do
+  let(:config) { RuboCop::Config.new }
+
+  # TODO: Write test code
+  #
+  # For example
+  it 'registers an offense when using `#bad_method`' do
+    expect_offense(<<~RUBY)
+      bad_method
+      ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
+    RUBY
+  end
+
+  it 'does not register an offense when using `#good_method`' do
+    expect_no_offenses(<<~RUBY)
+      good_method
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/rspec/chewy_strategy_spec.rb
+++ b/spec/rubocop/cop/rspec/chewy_strategy_spec.rb
@@ -3,19 +3,57 @@
 RSpec.describe RuboCop::Cop::RSpec::ChewyStrategy, :config do
   let(:config) { RuboCop::Config.new }
 
-  # TODO: Write test code
-  #
-  # For example
-  it 'registers an offense when using `#bad_method`' do
+  it 'registers an offense when using Chewy.strategy' do
     expect_offense(<<~RUBY)
-      bad_method
-      ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
+      let(:user) { Chewy.strategy(:atomic) { create(:user) } }
+                   ^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ChewyStrategy: Do not use Chewy.strategy in tests. Import data explicitly instead.
     RUBY
   end
 
-  it 'does not register an offense when using `#good_method`' do
-    expect_no_offenses(<<~RUBY)
-      good_method
+  it 'registers an offense for multiline Chewy.strategy usage' do
+    expect_offense(<<~RUBY)
+      let(:user) do
+        Chewy.strategy(:urgent) do
+        ^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ChewyStrategy: Do not use Chewy.strategy in tests. Import data explicitly instead.
+          create(:user)
+        end
+      end
+    RUBY
+  end
+  
+  it 'registers an offense when assigning Chewy.strategy to a variable' do
+    expect_offense(<<~RUBY)
+      before do
+        result = Chewy.strategy(:bypass) { create(:user) }
+                 ^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ChewyStrategy: Do not use Chewy.strategy in tests. Import data explicitly instead.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using Chewy.strategy in a before block' do
+    expect_offense(<<~RUBY)
+      before do
+        Chewy.strategy(:zero) { User.create!(name: 'Test') }
+        ^^^^^^^^^^^^^^^^^^^^^ RSpec/ChewyStrategy: Do not use Chewy.strategy in tests. Import data explicitly instead.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for different strategy types' do
+    expect_offense(<<~RUBY)
+      it 'creates a user' do
+        Chewy.strategy(:bypass) { create(:user) }
+        ^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ChewyStrategy: Do not use Chewy.strategy in tests. Import data explicitly instead.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using Chewy.strategy in a helper method' do
+    expect_offense(<<~RUBY)
+      def create_user
+        Chewy.strategy(:urgent) { create(:user) }
+        ^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ChewyStrategy: Do not use Chewy.strategy in tests. Import data explicitly instead.
+      end
     RUBY
   end
 end


### PR DESCRIPTION
Prevent to change the Chewy strategy in tests. Setting the strategy to atomic may try to import unnecessary data
for the test which result to a slower test suite.

Fix #69