### PR TITLE
Add Grape callback for UnnecessaryNamespace

### DIFF
--- a/lib/rubocop/cop/grape/unnecessary_namespace.rb
+++ b/lib/rubocop/cop/grape/unnecessary_namespace.rb
@@ -18,7 +18,7 @@ module RuboCop
               'Specify endpoint name with an argument: `get :some_path`.'
         HTTP_ACTIONS = Set.new(%i[get head put post patch delete])
         GRAPE_NAMESPACE_ALIAS = Set.new(%i[namespace resource resources])
-        METHOD_JUSTIFY_NAMESPACE = Set.new(%i[route_param namespaces resource resources version])
+        METHOD_JUSTIFY_NAMESPACE = Set.new(%i[route_param namespaces resource resources version before after finally after_validation before_validation])
 
         def_node_matcher :namespace?, <<~PATTERN
           (send nil? GRAPE_NAMESPACE_ALIAS ({sym | str} _))

--- a/lib/rubocop/cop/grape/unnecessary_namespace.rb
+++ b/lib/rubocop/cop/grape/unnecessary_namespace.rb
@@ -18,7 +18,16 @@ module RuboCop
               'Specify endpoint name with an argument: `get :some_path`.'
         HTTP_ACTIONS = Set.new(%i[get head put post patch delete])
         GRAPE_NAMESPACE_ALIAS = Set.new(%i[namespace resource resources])
-        METHOD_JUSTIFY_NAMESPACE = Set.new(%i[route_param namespaces resource resources version before after finally after_validation before_validation])
+        METHOD_JUSTIFY_NAMESPACE = Set.new(%i[route_param
+                                              namespaces
+                                              resource
+                                              resources
+                                              version
+                                              before
+                                              after
+                                              finally
+                                              after_validation
+                                              before_validation])
 
         def_node_matcher :namespace?, <<~PATTERN
           (send nil? GRAPE_NAMESPACE_ALIAS ({sym | str} _))

--- a/spec/rubocop/cop/grape/unnecessary_namespace_spec.rb
+++ b/spec/rubocop/cop/grape/unnecessary_namespace_spec.rb
@@ -228,4 +228,82 @@ RSpec.describe RuboCop::Cop::Grape::UnnecessaryNamespace, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when namespace contains Grape callbacks' do
+    expect_no_offenses(<<~RUBY)
+      namespace :my_namespace do
+        after_validation do
+          do_something
+        end
+
+        get do
+          something
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      namespace :my_namespace do
+        before do
+          authenticate!
+        end
+
+        get do
+          something
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      namespace :my_namespace do
+        after do
+          log_request
+        end
+
+        get do
+          something
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      namespace :my_namespace do
+        finally do
+          cleanup
+        end
+
+        get do
+          something
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      namespace :my_namespace do
+        before_validation do
+          normalize_params
+        end
+
+        get do
+          something
+        end
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      namespace :my_namespace do
+        before do
+          authenticate!
+        end
+
+        after_validation do
+          do_something
+        end
+
+        get do
+          something
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix #52 

This pull request enhances the RuboCop Grape cop to better recognize when a namespace is necessary due to the presence of Grape callbacks. The main change is expanding the set of methods that justify a namespace, and the test suite has been updated to ensure these callbacks are correctly handled.

**Improvements to namespace justification logic:**

* Added Grape callback methods (`before`, `after`, `finally`, `after_validation`, `before_validation`) to the set of methods that justify the use of a namespace in `UnnecessaryNamespace`. This prevents false positives when these callbacks are used within a namespace.