### PR TITLE
New cop aggregate_failures tag on example

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -59,6 +59,12 @@ RSpec/AggregateExamples:
     - validate_inclusion_of
     - validates_exclusion_of
 
+RSpec/AggregateFailuresTag:
+  Description: 'Checks that the `:aggregate_failures` tag is only used on examples, not on example groups.'
+  Enabled: true
+  Include:
+    - spec/**/*
+
 RSpec/ChewyStrategy:
   Description: 'Prevent using Chewy strategy in tests.'
   Enabled: true

--- a/lib/rubocop/cop/rspec/aggregate_failures_tag.rb
+++ b/lib/rubocop/cop/rspec/aggregate_failures_tag.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Checks that the `:aggregate_failures` tag is only used on examples,
+      # not on example groups.
+      #
+      # The `:aggregate_failures` tag only works on individual examples (`it`, `specify`, etc.),
+      # not on example groups (`describe`, `context`, etc.).
+      #
+      # @example
+      #   # bad
+      #   describe '#enabled?', :aggregate_failures do
+      #     # ...
+      #   end
+      #
+      #   context 'when enabled', :aggregate_failures do
+      #     # ...
+      #   end
+      #
+      #   # good
+      #   it 'returns true', :aggregate_failures do
+      #     # ...
+      #   end
+      #
+      #   specify 'the behavior', :aggregate_failures do
+      #     # ...
+      #   end
+      #
+      class AggregateFailuresTag < Base
+        MSG = 'The `:aggregate_failures` tag should only be used on examples, not on example groups.'
+
+        EXAMPLE_METHODS = %i[
+          it
+          specify
+          example
+          scenario
+          its
+          fit
+          fspecify
+          fexample
+          fscenario
+          focus
+          xit
+          xspecify
+          xexample
+          xscenario
+          skip
+          pending
+        ].freeze
+
+        RSPEC_METHODS = %i[
+          describe
+          context
+          feature
+          example_group
+          xdescribe
+          fdescribe
+          it
+          specify
+          example
+          scenario
+          its
+          fit
+          fspecify
+          fexample
+          fscenario
+          focus
+          xit
+          xspecify
+          xexample
+          xscenario
+          skip
+          pending
+        ].freeze
+
+        def on_block(node)
+          return unless rspec_block?(node)
+          return unless aggregate_failures_tag?(node)
+          return if example_method?(node)
+
+          # Create a range that includes the method call up to and including the 'do' keyword
+          send_node = node.send_node
+          range = send_node.source_range.join(node.loc.begin)
+          add_offense(range)
+        end
+
+        private
+
+        def rspec_block?(node)
+          send_node = node.send_node
+          return false unless send_node
+          return false unless send_node.send_type?
+
+          RSPEC_METHODS.include?(send_node.method_name)
+        end
+
+        def example_method?(node)
+          send_node = node.send_node
+          return false unless send_node
+
+          EXAMPLE_METHODS.include?(send_node.method_name)
+        end
+
+        def aggregate_failures_tag?(node)
+          send_node = node.send_node
+          return false unless send_node
+
+          send_node.arguments.any? do |arg|
+            if arg.sym_type? && arg.value == :aggregate_failures
+              true
+            elsif arg.hash_type?
+              arg.pairs.any? { |pair| pair.key.sym_type? && pair.key.value == :aggregate_failures }
+            else
+              false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/aggregate_failures_tag_spec.rb
+++ b/spec/rubocop/cop/rspec/aggregate_failures_tag_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::AggregateFailuresTag, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using :aggregate_failures on describe' do
+    expect_offense(<<~RUBY)
+      describe '#enabled?', :aggregate_failures do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using :aggregate_failures on context' do
+    expect_offense(<<~RUBY)
+      context 'when enabled', :aggregate_failures do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using :aggregate_failures on feature' do
+    expect_offense(<<~RUBY)
+      feature 'user login', :aggregate_failures do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        scenario 'successful login' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using :aggregate_failures on example_group' do
+    expect_offense(<<~RUBY)
+      example_group 'testing', :aggregate_failures do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'works' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using :aggregate_failures on xdescribe' do
+    expect_offense(<<~RUBY)
+      xdescribe '#enabled?', :aggregate_failures do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using :aggregate_failures on fdescribe' do
+    expect_offense(<<~RUBY)
+      fdescribe '#enabled?', :aggregate_failures do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when :aggregate_failures is in a hash argument on describe' do
+    expect_offense(<<~RUBY)
+      describe '#enabled?', aggregate_failures: true do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when :aggregate_failures is mixed with other tags on describe' do
+    expect_offense(<<~RUBY)
+      describe '#enabled?', :slow, :aggregate_failures, :integration do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RSpec/AggregateFailuresTag: The `:aggregate_failures` tag should only be used on examples, not on example groups.
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on it' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        it 'returns true', :aggregate_failures do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on specify' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        specify 'the behavior', :aggregate_failures do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on example' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        example 'the behavior', :aggregate_failures do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on scenario' do
+    expect_no_offenses(<<~RUBY)
+      feature 'user login' do
+        scenario 'successful login', :aggregate_failures do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on its' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        its(:enabled?, :aggregate_failures) { is_expected.to be true }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures in hash on it' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        it 'returns true', aggregate_failures: true do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on focused examples' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        fit 'returns true', :aggregate_failures do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using :aggregate_failures on skipped examples' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        xit 'returns true', :aggregate_failures do
+          expect(true).to be true
+          expect(false).to be false
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using other tags on describe' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?', :slow, :integration do
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when describe has no tags' do
+    expect_no_offenses(<<~RUBY)
+      describe '#enabled?' do
+        it 'returns true' do
+          expect(true).to be true
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Fix #71 

This pull request introduces a new RuboCop cop to enforce correct usage of the `:aggregate_failures` tag in RSpec tests. The cop ensures that the tag is only applied to individual examples (such as `it`, `specify`, etc.) and not to example groups (such as `describe`, `context`, etc.), which aligns with RSpec's intended behavior. The change includes configuration, implementation, and comprehensive tests for the new cop.

### New RSpec cop for aggregate_failures tag usage

* Added a new cop `RSpec/AggregateFailuresTag` to the configuration in `config/default.yml`, enabling it and specifying its scope to all spec files.
* Implemented the cop in `lib/rubocop/cop/rspec/aggregate_failures_tag.rb`. The cop checks RSpec blocks and flags usage of `:aggregate_failures` on example groups, providing a clear message to guide correct usage.