### PR TITLE
Add cops for Prefer using Sidekiq::Job over Sidekiq::Worker

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -156,12 +156,14 @@ Sidekiq/KeywordArguments:
   Enabled: true
   Include:
     - app/workers/**/*
+    - app/jobs/**/*
 
 Sidekiq/NoNilReturn:
   Description: 'Prevent early nil return in workers'
   Enabled: false
   Include:
     - app/workers/**/*
+    - app/jobs/**/*
 
 Sidekiq/PerformInline:
   Description: 'Suggest to use `perform_inline` instead of `new.perform` for Sidekiq workers.'
@@ -171,3 +173,26 @@ Sidekiq/SymbolArgument:
   Description: "Prevent passing keywords arguments in worker's perform method"
   Enabled: true
   SafeAutoCorrect: false
+
+Sidekiq/PreferJob:
+  Description: 'Prefer `Sidekiq::Job` over `Sidekiq::Worker`.'
+  Enabled: true
+  StyleGuide: https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology
+  Include:
+    - app/workers/**/*
+    - app/jobs/**/*
+
+Sidekiq/JobNaming:
+  Description: 'Job class name should end with `Job` instead of `Worker`.'
+  Enabled: true
+  StyleGuide: https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology
+  Include:
+    - app/workers/**/*
+    - app/jobs/**/*
+
+Sidekiq/JobLocation:
+  Description: 'Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.'
+  Enabled: true
+  StyleGuide: https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology
+  Include:
+    - app/workers/**/*

--- a/lib/rubocop/cop/sidekiq/helpers.rb
+++ b/lib/rubocop/cop/sidekiq/helpers.rb
@@ -7,7 +7,7 @@ module RuboCop
       module Helpers
         NODE_MATCHERS = lambda do
           def_node_matcher :sidekiq_include?, <<~PATTERN
-            (send nil? :include (const (const nil? :Sidekiq) :Worker))
+            (send nil? :include (const (const {nil? cbase} :Sidekiq) {:Worker :Job}))
           PATTERN
 
           def_node_matcher :includes_sidekiq?, <<~PATTERN

--- a/lib/rubocop/cop/sidekiq/job_location.rb
+++ b/lib/rubocop/cop/sidekiq/job_location.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module RuboCop
+  module Cop
+    module Sidekiq
+      # This cop checks that Sidekiq job classes with "Job" suffix are placed in the
+      # `app/jobs` directory instead of `app/workers` directory.
+      # This follows the modern Sidekiq convention where jobs should be organized
+      # in the appropriate directory structure.
+      #
+      # @example
+      #   # bad - Job class in app/workers directory
+      #   # app/workers/my_job.rb
+      #   class MyJob
+      #     include Sidekiq::Job
+      #   end
+      #
+      #   # good - Job class in app/jobs directory
+      #   # app/jobs/my_job.rb
+      #   class MyJob
+      #     include Sidekiq::Job
+      #   end
+      #
+      #   # good - Worker class can stay in app/workers (though not recommended)
+      #   # app/workers/my_worker.rb
+      #   class MyWorker
+      #     include Sidekiq::Worker
+      #   end
+      class JobLocation < Base
+        include Helpers
+
+        MSG = 'Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.'
+
+        def on_class(node)
+          return unless sidekiq_worker?(node)
+
+          class_name = extract_class_name(node)
+          return unless class_name
+          return unless class_name.end_with?('Job')
+
+          file_path = processed_source.buffer.name
+          return unless file_path.include?('app/workers/')
+
+          add_offense(node.children.first, message: MSG)
+        end
+
+        private
+
+        def extract_class_name(node)
+          name_node = node.children.first
+          return unless name_node&.const_type?
+
+          # Get the last part of the constant name (e.g., "EmailJob" from "MyApp::EmailJob")
+          name_node.children.last.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sidekiq/job_naming.rb
+++ b/lib/rubocop/cop/sidekiq/job_naming.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module RuboCop
+  module Cop
+    module Sidekiq
+      # This cop checks that Sidekiq job class names end with "Job" instead of "Worker".
+      # Since Sidekiq 6.3, it is best practice to use "Job" terminology over "Worker".
+      #
+      # @example
+      #   # bad
+      #   class MyWorker
+      #     include Sidekiq::Job
+      #   end
+      #
+      #   class ProcessDataWorker
+      #     include Sidekiq::Worker
+      #   end
+      #
+      #   # good
+      #   class MyJob
+      #     include Sidekiq::Job
+      #   end
+      #
+      #   class ProcessDataJob
+      #     include Sidekiq::Job
+      #   end
+      class JobNaming < Base
+        include Helpers
+
+        MSG = 'Job class name should end with `Job` instead of `Worker`.'
+
+        def_node_matcher :class_name, <<~PATTERN
+          (class (const _ $_) ...)
+        PATTERN
+
+        def on_class(node)
+          return unless sidekiq_worker?(node)
+
+          class_name = extract_class_name(node)
+          return unless class_name
+          return unless class_name.end_with?('Worker')
+
+          add_offense(node.children.first, message: MSG)
+        end
+
+        private
+
+        def extract_class_name(node)
+          name_node = node.children.first
+          return unless name_node&.const_type?
+
+          # Get the last part of the constant name (e.g., "EmailWorker" from "MyApp::EmailWorker")
+          name_node.children.last.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/sidekiq/prefer_job.rb
+++ b/lib/rubocop/cop/sidekiq/prefer_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module RuboCop
+  module Cop
+    module Sidekiq
+      # This cop checks for the use of `Sidekiq::Worker` and suggests using `Sidekiq::Job` instead.
+      # Since Sidekiq 6.3, it is best practice to use `Sidekiq::Job` over `Sidekiq::Worker`.
+      #
+      # @example
+      #   # bad
+      #   class MyWorker
+      #     include Sidekiq::Worker
+      #   end
+      #
+      #   # good
+      #   class MyJob
+      #     include Sidekiq::Job
+      #   end
+      class PreferJob < Base
+        extend AutoCorrector
+
+        MSG = 'Prefer `Sidekiq::Job` over `Sidekiq::Worker`.'
+
+        def_node_matcher :sidekiq_worker_include?, <<~PATTERN
+          (send nil? :include (const (const {nil? cbase} :Sidekiq) :Worker))
+        PATTERN
+
+        def on_send(node)
+          return unless sidekiq_worker_include?(node)
+
+          add_offense(node, message: MSG) do |corrector|
+            corrector.replace(node.arguments.first, 'Sidekiq::Job')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/sidekiq/job_location_spec.rb
+++ b/spec/rubocop/cop/sidekiq/job_location_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Sidekiq::JobLocation, :config do
+  let(:config) { RuboCop::Config.new }
+
+  context 'when Job class is in app/workers directory' do
+    it 'registers an offense for Job suffix with Sidekiq::Job' do
+      expect_offense(<<~RUBY, 'app/workers/my_job.rb')
+        class MyJob
+              ^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'registers an offense for Job suffix with Sidekiq::Worker' do
+      expect_offense(<<~RUBY, 'app/workers/process_data_job.rb')
+        class ProcessDataJob
+              ^^^^^^^^^^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+          include Sidekiq::Worker
+        end
+      RUBY
+    end
+
+    it 'registers an offense for namespaced Job class' do
+      expect_offense(<<~RUBY, 'app/workers/my_app/email_job.rb')
+        class MyApp::EmailJob
+              ^^^^^^^^^^^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'registers an offense for Job class inheriting from ApplicationWorker' do
+      expect_offense(<<~RUBY, 'app/workers/notification_job.rb')
+        class NotificationJob < ApplicationWorker
+              ^^^^^^^^^^^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Worker suffix' do
+      expect_no_offenses(<<~RUBY, 'app/workers/my_worker.rb')
+        class MyWorker
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for non-Sidekiq Job class' do
+      expect_no_offenses(<<~RUBY, 'app/workers/my_job.rb')
+        class MyJob
+          include SomeOtherModule
+        end
+      RUBY
+    end
+  end
+
+  context 'when Job class is in app/jobs directory' do
+    it 'does not register an offense for Job suffix with Sidekiq::Job' do
+      expect_no_offenses(<<~RUBY, 'app/jobs/my_job.rb')
+        class MyJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Job suffix with Sidekiq::Worker' do
+      expect_no_offenses(<<~RUBY, 'app/jobs/process_data_job.rb')
+        class ProcessDataJob
+          include Sidekiq::Worker
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for namespaced Job class' do
+      expect_no_offenses(<<~RUBY, 'app/jobs/my_app/email_job.rb')
+        class MyApp::EmailJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Job class inheriting from ApplicationWorker' do
+      expect_no_offenses(<<~RUBY, 'app/jobs/notification_job.rb')
+        class NotificationJob < ApplicationWorker
+        end
+      RUBY
+    end
+  end
+
+  context 'when Job class is in other directories' do
+    it 'does not register an offense for lib directory' do
+      expect_no_offenses(<<~RUBY, 'lib/my_job.rb')
+        class MyJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for spec directory' do
+      expect_no_offenses(<<~RUBY, 'spec/jobs/my_job_spec.rb')
+        class MyJobSpec
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for root directory' do
+      expect_no_offenses(<<~RUBY, 'my_job.rb')
+        class MyJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when class name contains Job but does not end with it' do
+    it 'does not register an offense in app/workers' do
+      expect_no_offenses(<<~RUBY, 'app/workers/job_manager.rb')
+        class JobManager
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when using fully qualified Sidekiq modules' do
+    it 'registers an offense for Job suffix with ::Sidekiq::Job in app/workers' do
+      expect_offense(<<~RUBY, 'app/workers/my_job.rb')
+        class MyJob
+              ^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+          include ::Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Job suffix with ::Sidekiq::Job in app/jobs' do
+      expect_no_offenses(<<~RUBY, 'app/jobs/my_job.rb')
+        class MyJob
+          include ::Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when multiple classes are defined' do
+    it 'registers offenses for all Job-suffixed classes in app/workers' do
+      expect_offense(<<~RUBY, 'app/workers/multiple_jobs.rb')
+        class FirstJob
+              ^^^^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+          include Sidekiq::Job
+        end
+
+        class SecondWorker
+          include Sidekiq::Job
+        end
+
+        class ThirdJob
+              ^^^^^^^^ Sidekiq/JobLocation: Job class with `Job` suffix should be placed in `app/jobs` directory instead of `app/workers`.
+          include Sidekiq::Worker
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/sidekiq/job_naming_spec.rb
+++ b/spec/rubocop/cop/sidekiq/job_naming_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Sidekiq::JobNaming, :config do
+  let(:config) { RuboCop::Config.new }
+
+  context 'when class name ends with Worker and includes Sidekiq::Job' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class MyWorker
+              ^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when class name ends with Worker and includes Sidekiq::Worker' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class ProcessDataWorker
+              ^^^^^^^^^^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include Sidekiq::Worker
+        end
+      RUBY
+    end
+  end
+
+  context 'when class name ends with Job and includes Sidekiq::Job' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class MyJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when class name ends with Job and includes Sidekiq::Worker' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class ProcessDataJob
+          include Sidekiq::Worker
+        end
+      RUBY
+    end
+  end
+
+  context 'when class does not include Sidekiq modules' do
+    it 'does not register an offense even if name ends with Worker' do
+      expect_no_offenses(<<~RUBY)
+        class MyWorker
+          include SomeOtherModule
+        end
+      RUBY
+    end
+  end
+
+  context 'when class inherits from ApplicationWorker' do
+    it 'registers an offense if name ends with Worker' do
+      expect_offense(<<~RUBY)
+        class EmailWorker < ApplicationWorker
+              ^^^^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+        end
+      RUBY
+    end
+
+    it 'does not register an offense if name ends with Job' do
+      expect_no_offenses(<<~RUBY)
+        class EmailJob < ApplicationWorker
+        end
+      RUBY
+    end
+  end
+
+  context 'when using namespaced class names' do
+    it 'registers an offense for Worker suffix' do
+      expect_offense(<<~RUBY)
+        class MyApp::EmailWorker
+              ^^^^^^^^^^^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Job suffix' do
+      expect_no_offenses(<<~RUBY)
+        class MyApp::EmailJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when class name contains Worker but does not end with it' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class WorkerManager
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when using fully qualified Sidekiq modules' do
+    it 'registers an offense for Worker suffix with ::Sidekiq::Job' do
+      expect_offense(<<~RUBY)
+        class MyWorker
+              ^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include ::Sidekiq::Job
+        end
+      RUBY
+    end
+
+    it 'registers an offense for Worker suffix with ::Sidekiq::Worker' do
+      expect_offense(<<~RUBY)
+        class MyWorker
+              ^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include ::Sidekiq::Worker
+        end
+      RUBY
+    end
+  end
+
+  context 'when multiple classes are defined' do
+    it 'registers offenses for all Worker-suffixed classes' do
+      expect_offense(<<~RUBY)
+        class FirstWorker
+              ^^^^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include Sidekiq::Job
+        end
+
+        class SecondJob
+          include Sidekiq::Job
+        end
+
+        class ThirdWorker
+              ^^^^^^^^^^^ Sidekiq/JobNaming: Job class name should end with `Job` instead of `Worker`.
+          include Sidekiq::Worker
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/sidekiq/prefer_job_spec.rb
+++ b/spec/rubocop/cop/sidekiq/prefer_job_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Sidekiq::PreferJob, :config do
+  let(:config) { RuboCop::Config.new }
+
+  context 'when using Sidekiq::Worker' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class MyWorker
+          include Sidekiq::Worker
+          ^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/PreferJob: Prefer `Sidekiq::Job` over `Sidekiq::Worker`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyWorker
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when using Sidekiq::Job' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class MyJob
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when including other modules' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class MyClass
+          include SomeOtherModule
+        end
+      RUBY
+    end
+  end
+
+  context 'when including Sidekiq::Worker in multiple classes' do
+    it 'registers offenses for all occurrences' do
+      expect_offense(<<~RUBY)
+        class FirstWorker
+          include Sidekiq::Worker
+          ^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/PreferJob: Prefer `Sidekiq::Job` over `Sidekiq::Worker`.
+        end
+
+        class SecondWorker
+          include Sidekiq::Worker
+          ^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/PreferJob: Prefer `Sidekiq::Job` over `Sidekiq::Worker`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class FirstWorker
+          include Sidekiq::Job
+        end
+
+        class SecondWorker
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when using fully qualified Sidekiq::Worker' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class MyWorker
+          include ::Sidekiq::Worker
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/PreferJob: Prefer `Sidekiq::Job` over `Sidekiq::Worker`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyWorker
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when including Sidekiq::Worker with other modules' do
+    it 'registers an offense only for Sidekiq::Worker' do
+      expect_offense(<<~RUBY)
+        class MyWorker
+          include SomeOtherModule
+          include Sidekiq::Worker
+          ^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/PreferJob: Prefer `Sidekiq::Job` over `Sidekiq::Worker`.
+          include AnotherModule
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MyWorker
+          include SomeOtherModule
+          include Sidekiq::Job
+          include AnotherModule
+        end
+      RUBY
+    end
+  end
+
+  context 'when using Sidekiq::Worker in a module' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        module MyModule
+          include Sidekiq::Worker
+          ^^^^^^^^^^^^^^^^^^^^^^^ Sidekiq/PreferJob: Prefer `Sidekiq::Job` over `Sidekiq::Worker`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module MyModule
+          include Sidekiq::Job
+        end
+      RUBY
+    end
+  end
+
+  context 'when using similar but different module names' do
+    it 'does not register an offense for Sidekiq::WorkerExtension' do
+      expect_no_offenses(<<~RUBY)
+        class MyWorker
+          include Sidekiq::WorkerExtension
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for MySidekiq::Worker' do
+      expect_no_offenses(<<~RUBY)
+        class MyWorker
+          include MySidekiq::Worker
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces new RuboCop cops and updates configuration to enforce modern Sidekiq best practices, focusing on terminology and file organization for job classes. It adds three new cops: `PreferJob`, `JobNaming`, and `JobLocation`, which respectively enforce the use of `Sidekiq::Job` over `Sidekiq::Worker`, require job class names to end with `Job`, and ensure job classes are placed in the correct directory. The configuration and helper logic are updated to support these rules, and comprehensive specs are included to validate the new cops.

**Sidekiq job best practices enforcement:**

* Added `Sidekiq/PreferJob`, `Sidekiq/JobNaming`, and `Sidekiq/JobLocation` cops to RuboCop, enforcing use of `Sidekiq::Job`, requiring job class names to end with `Job`, and ensuring job classes are placed in `app/jobs` instead of `app/workers`. [[1]](diffhunk://#diff-cb36d0ae1c8bdfb06df795e4067e9d5cf2437c19a30fccbd177712fbed1a3a7dR1-R40) [[2]](diffhunk://#diff-314cb5410e8e50f7767a636b358adaaccc7e706506ddafbc4feb7deb3415fd37R1-R60) [[3]](diffhunk://#diff-7594ae0c9dfc6166bd151650374661e04d9a6b079e121039e5f8b215cafa2c46R1-R61)
* Updated RuboCop configuration in `config/default.yml` to enable the new cops and include both `app/workers/**/*` and `app/jobs/**/*` directories for all Sidekiq-related cops. [[1]](diffhunk://#diff-3653213e3a153018a75cc7b2536b1d0217a6d8d75188d71cf45441812f789698R159-R166) [[2]](diffhunk://#diff-3653213e3a153018a75cc7b2536b1d0217a6d8d75188d71cf45441812f789698R176-R198)

**Supporting logic and matcher improvements:**

* Enhanced helper logic in `lib/rubocop/cop/sidekiq/helpers.rb` to match both `Sidekiq::Worker` and `Sidekiq::Job`, supporting fully qualified and cbase references.